### PR TITLE
Fix bug in mapper 3 (CNROM) - need to mask bank switch with 0x03

### DIFF
--- a/nes/mapper.cpp
+++ b/nes/mapper.cpp
@@ -259,7 +259,9 @@ CNRom::~CNRom()
 
 void CNRom::prg_storeb(u16 addr, u8 val)
 {
-    _chrBank = val;
+    // CNROM only supports 32KB of CHR ROM, but some games write values
+    // such as $FF to switch to bank 3 so we need to mask with 0x03
+    _chrBank = val & 0x03;
 }
 
 u8 CNRom::chr_loadb(u16 addr)


### PR DESCRIPTION
This fix along with APU IRQ support gets another set of games working.